### PR TITLE
#166467446 AddQuestion access control

### DIFF
--- a/app/controllers/v1/questions_controller.rb
+++ b/app/controllers/v1/questions_controller.rb
@@ -5,7 +5,7 @@ module V1
     # GET /questions
     def index
       #get questions from all users
-      @questions = current_user.questions
+      @questions = Question.all.order(updated_at: :desc)
       json_response(@questions)
     end
 
@@ -23,13 +23,13 @@ module V1
 
     # PATCH/PUT /questions/1
     def update
-      @question.update(question_params)
+      author_verification(current_user, @question, "update")
       head :no_content
     end
 
     # DELETE /questions/1
     def destroy
-      @question.destroy
+      author_verification(current_user, @question, "delete")
       head :no_content
     end
 
@@ -43,5 +43,18 @@ module V1
       def question_params
         params.permit(:body)
       end
+
+    # Only enble authors to edit or delete questions
+    def author_verification (current_user, question, action)
+      unless current_user.id == question.created_by.to_i
+        return
+      end
+      if action == "update"
+        question.update(question_params)
+      else
+        question.destroy
+      end
+    end
+
   end
 end


### PR DESCRIPTION
#### What does this PR do?
- adds edit and delete restrictions to authors of the question
#### Description of Task to be completed?
- ensure a user only a question the author is able to edit or delete their question

#### How should this be manually tested?
- checkout `ch-question-access-control-166467446`
- signup to the application
- add a question 
- signup as another user
- try editing or deleting a question by the first user
- if you get the question of the first user, it should exist and be the same
- create your own question
- you should be able to edit or delete it

#### Any background context you want to provide?
N/A
#### What are the relevant PT Stories?
[#166467446](https://www.pivotaltracker.com/story/show/166467446)
#### Screenshots (if appropriate)
- Add screenshot
#### Questions:
N/A
